### PR TITLE
Generate valid html

### DIFF
--- a/includes/Intuition.php
+++ b/includes/Intuition.php
@@ -1022,7 +1022,7 @@ class Intuition {
 
 		// Build output
 		return
-			"<div class=\"int-promobox\"><p><a href=\"{$this->getDashboardReturnToUrl()}\">$img</a> "
+			"<div class=\"int-promobox\"><p><a href=\"" . htmlspecialchars( $this->getDashboardReturnToUrl() ) . "\">$img</a> "
 			. "$powered {$this->dashboardBacklink()} $helpTranslateLink</p></div>";
 	}
 


### PR DESCRIPTION
Intuition::getDashboardReturnToUrl: Replace & with \&amp; as separator.
E.g. Intuition::getPromoBox sends the result from http_build_query
through IntuitionUtil::tag (which uses htmlspecialchars on the input).
This also means that setting arg_separator.output to '\&amp;' won't work
very well.