### PR TITLE
Add support for dcatap

### DIFF
--- a/language/messages/dcatap/en.json
+++ b/language/messages/dcatap/en.json
@@ -1,0 +1,12 @@
+{
+	"@metadata": {
+		"authors": ["Lokal_Profil"]
+	},
+	"dcatap-dataset-live-title": "Live access",
+	"dcatap-dataset-live-description": "The live version of the data, includes entities and properties. Only non-deprecated formats are listed as distributions.",
+	"dcatap-dataset-dump-title": "Entity dump of $1",
+	"dcatap-dataset-dump-description": "A static dump of all entites for the given date.",
+	"dcatap-distribution-ld-description": "The Linked Data endpoint. Format is resolved through content negotiation.",
+	"dcatap-distribution-api-description": "The MediaWiki API endpoint. Format is given through the \"format\" parameter.",
+	"dcatap-distribution-dump-description": "A gziped $1 file."
+}

--- a/language/messages/dcatap/qqq.json
+++ b/language/messages/dcatap/qqq.json
@@ -1,0 +1,12 @@
+{
+	"@metadata": {
+		"authors": ["Lokal_Profil"]
+	},
+	"dcatap-dataset-live-title": "The title for the live access dataset",
+	"dcatap-dataset-live-description": "The description of the live access dataset. For terminology see https://www.wikidata.org/wiki/Wikidata:Glossary. For deprecation see https://en.wikipedia.org/wiki/Deprecation.",
+	"dcatap-dataset-dump-title": "The title for the entity dump where $1 is the date of the dump in the format YYYYMMDD",
+	"dcatap-dataset-dump-description": "The description of the entity dump for the given date.",
+	"dcatap-distribution-ld-description": "The description of the Linked Data endpoint. For content negotiation see https://en.wikipedia.org/wiki/Content_negotiation",
+	"dcatap-distribution-api-description": "The description of the MediaWiki API endpoint. Leave \"format\" untranslated.",
+	"dcatap-distribution-dump-description": "The description of a dump file where $1 is the file format."
+}

--- a/language/messages/dcatap/sv.json
+++ b/language/messages/dcatap/sv.json
@@ -1,0 +1,12 @@
+{
+	"@metadata": {
+		"authors": ["Lokal_Profil"]
+	},
+	"dcatap-dataset-live-title": "Direkt åtkomst",
+	"dcatap-dataset-live-description": "The aktuella versionen av datan, inkluderande objekt och egenskaper. Endast icke-utfasade format listas för distributionerna.",
+	"dcatap-dataset-dump-title": "Objekt dump från $1",
+	"dcatap-dataset-dump-description": "En statisk dump av alla objekt för det angivna datumet.",
+	"dcatap-distribution-ld-description": "Länkade data-accesspunkten. Formatet ges genom content negotiation.",
+	"dcatap-distribution-api-description": "MediaWiki API-accesspunkten. Formatet ges genom \"format\"-parametern.",
+	"dcatap-distribution-dump-description": "En gzipad $1-fil."
+}


### PR DESCRIPTION
Adds i18n strings for use in the DCAT for Wikibase script

Repo: https://github.com/lokal-profil/DCAT
Gerrit: https://gerrit.wikimedia.org/r/#/c/219800
Phabricator: https://phabricator.wikimedia.org/T103087