### PR TITLE
Add Intuition::addAvailableLanguage() method

### DIFF
--- a/src/Intuition.php
+++ b/src/Intuition.php
@@ -749,6 +749,17 @@ class Intuition {
 	}
 
 	/**
+	 * Add a language that isn't listed in Intuition's included language list.
+	 * @param string $code The language code (with hyphens, not underscores).
+	 * @param string $name The localized name of the language.
+	 */
+	public function addAvailableLang( $code, $name ) {
+		$this->getLangNames();
+		$this->langNames[$code] = $name;
+		$this->availableLanguages[$code] = $name;
+	}
+
+	/**
 	 * Generate a list of all languages available in at least one domain.
 	 * @return array Language names keyed by language code
 	 */

--- a/tests/phpunit/IntuitionTest.php
+++ b/tests/phpunit/IntuitionTest.php
@@ -878,4 +878,15 @@ class IntuitionTest extends Krinkle\Intuition\IntuitionTestCase {
 		$this->assertSame( true, $this->i18n->setUseRequestParam( true ), 'set true' );
 		$this->assertSame( true, $this->i18n->setUseRequestParam( false ), 'set true' );
 	}
+
+	/**
+	 * @covers \Krinkle\Intuition\Intuition::addAvailableLang()
+	 */
+	public function testAddAvailableLang() {
+		// This is a valid locale http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_FI
+		// It is unlikely to be added to langlist.php (if it is, this test will need to be changed).
+		$this->assertArrayNotHasKey( 'en-FI', $this->i18n->getAvailableLangs() );
+		$this->i18n->addAvailableLang( 'en-FI', 'Finnish English' );
+		$this->assertArrayHasKey( 'en-FI', $this->i18n->getAvailableLangs() );
+	}
 }

--- a/tests/phpunit/IntuitionTestCase.php
+++ b/tests/phpunit/IntuitionTestCase.php
@@ -16,6 +16,7 @@ class IntuitionTestCase extends TestCase {
 
 	public static $time = 1;
 
+	/** @var Intuition */
 	protected $i18n;
 
 	protected $live = [];


### PR DESCRIPTION
This adds a new method with which to add local overrides to the
available languages list.

Bug: GH #88