### PR TITLE
Correct data type of $dir argument in Intuition::registerDomain()

### DIFF
--- a/src/Intuition.php
+++ b/src/Intuition.php
@@ -627,7 +627,7 @@ class Intuition {
 	 * Register a custom domain.
 	 *
 	 * @param string $domain Name of domain
-	 * @param array $dir Path to messages directory
+	 * @param string $dir Path to messages directory
 	 * @param array $info [optional] Domain info
 	 * @return array
 	 */


### PR DESCRIPTION
Per the README `$dir` appears to be a string and not an array.

Apart this PR, since we're requiring PHP >= 7.0, we might consider reworking methods to use [type declarations](https://secure.php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration).