### PR TITLE
Extend lang normalization to only accept alphanums and hyphen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [Unreleased]
+
+### Changed
+
+* `Intuition::setLang()` has more strict normalization
+  to ensure that invalid strings can't be used.
+
 ## v2.1.0 (2019-11-24)
 
 ### Changed

--- a/src/Intuition.php
+++ b/src/Intuition.php
@@ -213,6 +213,11 @@ class Intuition {
 		if ( !IntuitionUtil::nonEmptyStr( $lang ) ) {
 			return false;
 		}
+		// Pre-normalize the lang string to prevent invalid values.
+		$lang = trim( preg_replace( '/[^a-z0-9-]+/', '-', strtolower( (string)$lang ) ), '-' );
+		if ( !$lang ) {
+			return false;
+		}
 		$this->currentLanguage = $this->normalizeLang( $lang );
 		return true;
 	}

--- a/tests/phpunit/IntuitionTest.php
+++ b/tests/phpunit/IntuitionTest.php
@@ -73,7 +73,16 @@ class IntuitionTest extends Krinkle\Intuition\IntuitionTestCase {
 			$this->i18n->msg( 'test-value', 'test-domain' ),
 			'Change default lang'
 		);
+		// Language must be a non-empty string.
 		$this->assertFalse( $this->i18n->setLang( 42 ), 'Bad value' );
+		// Language is normalized to lowercase and hyphen-separated.
+		$this->i18n->setLang( 'en_AU' );
+		$this->assertEquals( 'en-au', $this->i18n->getLang() );
+		$this->i18n->setLang( '"bad" lang <string>' );
+		$this->assertEquals( 'bad-lang-string', $this->i18n->getLang(), 'Strip invalid characters.' );
+		$this->i18n->setLang( '*^-.' );
+		// Lang doesn't change from previous if new value is invalid.
+		$this->assertEquals( 'bad-lang-string', $this->i18n->getLang(), 'Only invalid characters.' );
 	}
 
 	/**


### PR DESCRIPTION
This prevents the language being set to an invalid value.
At the moment, it's possible to use setLang() with an invalid
language code, and therefore for getLang() to return something
invalid.

One fix might be to check the provided lang against the list of
available languages, but that might be annoying for some usages,
so instead this just makes the language code normalization more
strict: replacing anything that's not alphanumeric or hyphen
with a hyphen (and then trimming hyphens from the string). This
isn't always going to be a valid language code, but it'll always
be safe to use wherever a language code is wanted.

https://phabricator.wikimedia.org/T239871