### PR TITLE
docs: Update Travis url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Packagist](https://img.shields.io/packagist/v/krinkle/intuition.svg?style=flat)](https://packagist.org/packages/Krinkle/intuition) [![Build Status](https://travis-ci.org/Krinkle/intuition.svg?branch=master)](https://travis-ci.org/Krinkle/intuition) [![Coverage Status](https://coveralls.io/repos/github/Krinkle/intuition/badge.svg?branch=master)](https://coveralls.io/github/Krinkle/intuition?branch=master)
+[![Packagist](https://img.shields.io/packagist/v/krinkle/intuition.svg?style=flat)](https://packagist.org/packages/Krinkle/intuition) [![Build Status](https://travis-ci.com/Krinkle/intuition.svg?branch=master)](https://travis-ci.com/Krinkle/intuition) [![Coverage Status](https://coveralls.io/repos/github/Krinkle/intuition/badge.svg?branch=master)](https://coveralls.io/github/Krinkle/intuition?branch=master)
 
 # Intuition
 


### PR DESCRIPTION
Migrated to the new dot-com.