### PR TITLE
Cast message variables to strings before using

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,6 +22,8 @@ jobs:
             php: "7.4"
           - os: ubuntu-20.04
             php: "8.0"
+          - os: ubuntu-20.04
+            php: "8.1"
     # Use "PHP 0.0" as job name instead of "php (ubuntu-, 0.0)"
     name: PHP ${{ matrix.php }}
     runs-on: ${{ matrix.os }}

--- a/src/Intuition.php
+++ b/src/Intuition.php
@@ -455,7 +455,7 @@ class Intuition {
 		// Replace variables
 		foreach ( $options['variables'] as $i => $val ) {
 			$n = $i + 1;
-			$msg = str_replace( "\$$n", $val, $msg );
+			$msg = str_replace( "\$$n", strval( $val ), $msg );
 		}
 
 		if ( $options['parsemag'] === true ) {

--- a/tests/phpunit/IntuitionTest.php
+++ b/tests/phpunit/IntuitionTest.php
@@ -234,6 +234,18 @@ class IntuitionTest extends Krinkle\Intuition\IntuitionTestCase {
 			] ),
 			'HTML escaped (raw variables)'
 		);
+
+		$this->assertSame(
+			'l&<€ and 7',
+			$this->i18n->msg( 'example', [ 'variables' => [ 7 ] ] ),
+			'Integer variable is cast to string.'
+		);
+
+		$this->assertSame(
+			'l&<€ and bar',
+			$this->i18n->msg( 'example', [ 'variables' => [ new SimpleXMLElement( '<foo>bar</foo>' ) ] ] ),
+			'Object variable is cast to string.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
PHP 8.1 deprecates passing anything other than strings to str_replace,
such as integers. This means that message variables need to all be
strings, which is fine — but it's sometimes easier to be to pass
different types.

Also add PHP 8.1 to CI.